### PR TITLE
feat: measure pulse on bucket

### DIFF
--- a/src/bucket.js
+++ b/src/bucket.js
@@ -28,7 +28,7 @@ class Bucket {
     const now = Date.now()
     this.window.push({ amount: n, date: now })
     for (let i = 0; i < this.window.length; ++i) {
-      if (this.window[i].date + DEFAULT_WINDOW > now) {
+      if (this.window[i].date + DEFAULT_WINDOW < now) {
         this.window.splice(i, 1)
         --i
         continue

--- a/src/bucket.js
+++ b/src/bucket.js
@@ -28,12 +28,12 @@ class Bucket {
     const now = Date.now()
     this.window.push({ amount: n, date: now })
     for (let i = 0; i < this.window.length; ++i) {
-      if (item.date + DEFAULT_WINDOW > now) {
+      if (this.window[i].date + DEFAULT_WINDOW > now) {
         this.window.splice(i, 1)
         --i
         continue
       }
-      total += item.amount
+      total += this.window[i].amount
     }
 
     this.pulse = total / (DEFAULT_THROUGHPUT * (DEFAULT_WINDOW / 1000))

--- a/src/bucket.js
+++ b/src/bucket.js
@@ -15,6 +15,7 @@ class Bucket {
 
     // sliding window of payment events
     this.window = []
+    this.lastPulse = 0
     this.pulse = 0
   }
 
@@ -36,6 +37,7 @@ class Bucket {
       total += this.window[i].amount
     }
 
+    this.lastPulse = this.pulse
     this.pulse = total / (DEFAULT_THROUGHPUT * (DEFAULT_WINDOW / 1000))
     this.balance = Math.min(
       this.balance + n,


### PR DESCRIPTION
Pulse is a useful measurement to tell how quickly someone is streaming payments to you. Pulse is the actual throughput over an interval divided by the expected throughput over that interval. We use a default expected throughput/second of 100,000 drips. You can look for a pulse of >0 to tell whether the user is WM-enabled at all in the interval, and you could look for a pulse of 0.5 to make sure they're paying at least 50,000 drips/s