### PR TITLE
fix: setSendMax of null error

### DIFF
--- a/src/stream-wrapper.js
+++ b/src/stream-wrapper.js
@@ -67,6 +67,14 @@ class StreamWrapper extends EventEmitter {
       ...this.streamOpts
     })
 
+    this.connection
+      .once('close', () => {
+        this.state = StreamStates.NOT_CONNECTED
+      })
+      .once('error', (_err) => {
+        this.state = StreamStates.NOT_CONNECTED
+      })
+
     this.stream = this.connection.createStream()
     this.state = StreamStates.CONNECTED
     this.emit('connected')


### PR DESCRIPTION
```
(node:26) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'setSendMax' of null
    at Payer.pay (/app/node_modules/web-monetization-receiver/src/payer.js:42:12)
    at process._tickCallback (internal/process/next_tick.js:68:7)
```

If `pay()` is called twice, but the second call occurs before the STREAM connection is established, `receiver.getStream()` would return `null`. This patch stores a promise to the receiver in `receivers` instead of the receiver. The promise resolves when the connection is established.

---

Also, if `StreamWrapper#connect()` is called and its old stream has closed, it should reconnect before resolving and get a new stream.